### PR TITLE
Fixes prediction error regarding LOIC and Pull.

### DIFF
--- a/characters/robo/RoboExtra.gd
+++ b/characters/robo/RoboExtra.gd
@@ -29,11 +29,13 @@ func get_extra():
 		"armor_enabled": $"%ArmorEnabled".pressed,
 		"nade_activated": $"%NadeActive".pressed and $"%NadeActive".visible,
 		"pull_enabled": $"%PullEnabled".pressed and $"%PullEnabled".visible,
-		"loic_dir": loic.get_data() if loic.is_visible_in_tree() else {"x": fighter.loic_dir, "y": 0},
 		"drive_cancel": drive_pressed() if fighter.stance != "Drive" else !drive_pressed(),
 		"bounce": bounce.get_data(),
 		"honk": $"%HonkEnabled".pressed
 	}
+if loic.is_visible_in_tree():
+		extra["loic_dir"] = loic.get_data()
+	return extra
 
 func drive_pressed():
 	return $"%DriveCancel".pressed and $"%DriveCancel".visible

--- a/characters/stickman/NinjaExtra.gd
+++ b/characters/stickman/NinjaExtra.gd
@@ -104,7 +104,7 @@ func update_missed_block():
 func get_extra():
 	var extra = {
 		"explode": bomb_button.pressed,
-		"pull": pull_button.pressed if pull_button.visible else fighter.pulling,
+		"pull": pull_button.visible and pull_button.pressed,
 		"detach": detach_button.pressed,
 #		"store": store_button.pressed,
 		"release": release_button.pressed,
@@ -116,3 +116,4 @@ func reset():
 	bomb_button.set_pressed_no_signal(false)
 	release_button.set_pressed_no_signal(false)
 	store_button.set_pressed_no_signal(false)
+	pull_button.set_pressed_no_signal(false)


### PR DESCRIPTION
In current yomi, if the opponent ninja chooses a move and the player character is active before that, the pull button disappears and sets pull state to null, this causes pull for ninja in prediction for the player to be based on what they had last hovered in prediction. I've updated it to no longer set it to null when pull isn't visible.

Same applies to robot loic and changing direction. When the button disappears, its value in prediction is set by what you had last hovered in the turn before.